### PR TITLE
feat: add Helix config with soft wrap enabled by default

### DIFF
--- a/dot_config/helix/config.toml
+++ b/dot_config/helix/config.toml
@@ -1,0 +1,3 @@
+# Visually wraps all lines too long to fit the current editor without horizontal scrolling.
+[editor.soft-wrap]
+enable = true


### PR DESCRIPTION
## Summary

- Creates `dot_config/helix/config.toml` (applied as `~/.config/helix/config.toml` via chezmoi).
- Enables `editor.soft-wrap` so long lines wrap visually instead of extending off-screen.

## Test plan

- [ ] Run `chezmoi diff` — confirm it shows the new file being added to `~/.config/helix/config.toml`.
- [ ] Run `chezmoi apply` — apply the config.
- [ ] Open a file with long lines in Helix (`hx <file>`) and confirm lines wrap at the window edge.

https://claude.ai/code/session_018uKNWAnn5EjhJssfiUU6xw

---
_Generated by [Claude Code](https://claude.ai/code/session_018uKNWAnn5EjhJssfiUU6xw)_