### PR TITLE
feat: add zsh config and improve cross-shell PATH/environment consistency

### DIFF
--- a/.chezmoitemplates/config.nu
+++ b/.chezmoitemplates/config.nu
@@ -112,8 +112,6 @@ if ($texlive_bin | path exists) {
 # Aliases.
 ##
 
-# (none, at the moment)
-
 # `td` — Todoist CLI via pinned npx fetch (no global install).
 alias td = npx --package=@doist/todoist-cli@1.60.0 -- td
 

--- a/dot_bash_profile.tmpl
+++ b/dot_bash_profile.tmpl
@@ -39,6 +39,12 @@ if [ -d "$HOME/.cargo/bin" ] ; then
     PATH="$HOME/.cargo/bin:$PATH"
 fi
 
+# Configure Volta.
+export VOLTA_HOME="$HOME/.volta"
+if [ -d "$VOLTA_HOME/bin" ] ; then
+    PATH="$VOLTA_HOME/bin:$PATH"
+fi
+
 {{ with .chezmoi.osRelease }}
   {{ if eq .id "ubuntu" }}
 ##

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -27,6 +27,10 @@ setopt HIST_IGNORE_SPACE
 [[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
 [[ -d "$HOME/.cargo/bin" ]] && path=("$HOME/.cargo/bin" $path)
 
+# Configure Volta.
+export VOLTA_HOME="$HOME/.volta"
+[[ -d "$VOLTA_HOME/bin" ]] && path=("$VOLTA_HOME/bin" $path)
+
 ##
 # Completion.
 #

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,0 +1,23 @@
+##
+# History — mirrors nushell: virtually unlimited, write on each command, per-session isolation.
+##
+
+HISTFILE=~/.zsh_history
+HISTSIZE=5000000000
+SAVEHIST=5000000000
+setopt INC_APPEND_HISTORY   # sync_on_enter equivalent: write each command immediately
+setopt HIST_IGNORE_DUPS
+setopt HIST_IGNORE_SPACE
+
+##
+# Completion.
+##
+
+autoload -Uz compinit && compinit
+
+##
+# Aliases.
+##
+
+# `td` — Todoist CLI via pinned npx fetch (no global install).
+alias td='npx --package=@doist/todoist-cli@1.60.0 -- td'

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -17,13 +17,31 @@ setopt HIST_IGNORE_DUPS
 setopt HIST_IGNORE_SPACE
 
 ##
+# PATH.
+#
+# Mirror the same additions as dot_bash_profile.tmpl so interactive zsh sessions have the same
+# binaries available (important on macOS where zsh is the default login shell).
+##
+
+[[ -d "$HOME/bin" ]] && path=("$HOME/bin" $path)
+[[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
+[[ -d "$HOME/.cargo/bin" ]] && path=("$HOME/.cargo/bin" $path)
+
+##
 # Completion.
 #
 # Initializes zsh's completion system so that tab completion works for commands, flags, and
 # arguments. Without this, only basic filename completion is available.
+# Only rebuilds the completion dump when it is older than 24 hours to avoid startup latency;
+# compinit -C skips the security check on subsequent loads (safe on a personal machine).
 ##
 
-autoload -Uz compinit && compinit
+autoload -Uz compinit
+if [[ -n ${ZDOTDIR:-$HOME}/.zcompdump(#qN.mh+24) ]]; then
+  compinit
+else
+  compinit -C
+fi
 
 ##
 # Aliases.

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,16 +1,26 @@
 ##
 # History — mirrors nushell: virtually unlimited, write on each command, per-session isolation.
+#
+# Note: Zsh has no truly-unlimited flag (no -1 equivalent); the large integer is a practical
+# ceiling. EXTENDED_HISTORY stores each entry as `: timestamp:elapsed;command`, providing
+# timestamps and command duration natively — the closest zsh gets to structured storage.
+# INC_APPEND_HISTORY_TIME writes after the command completes (so elapsed time is known),
+# mirroring nushell's sync_on_enter = true. Per-session isolation is zsh's default.
 ##
 
 HISTFILE=~/.zsh_history
 HISTSIZE=5000000000
 SAVEHIST=5000000000
-setopt INC_APPEND_HISTORY   # sync_on_enter equivalent: write each command immediately
+setopt EXTENDED_HISTORY         # store `: timestamp:elapsed;command` format
+setopt INC_APPEND_HISTORY_TIME  # write after completion to capture elapsed; mirrors sync_on_enter
 setopt HIST_IGNORE_DUPS
 setopt HIST_IGNORE_SPACE
 
 ##
 # Completion.
+#
+# Initializes zsh's completion system so that tab completion works for commands, flags, and
+# arguments. Without this, only basic filename completion is available.
 ##
 
 autoload -Uz compinit && compinit


### PR DESCRIPTION
## Summary

- Creates `dot_zshrc` (deploys to `~/.zshrc`) as a new managed shell config, providing a
  consistent zsh experience when it's used as a fallback or default shell (notably on macOS).
- Adds Volta PATH management to both `dot_bash_profile.tmpl` and `dot_zshrc`, mirroring what
  nushell already does (`VOLTA_HOME` + prepend `$VOLTA_HOME/bin`).
- Removes a stale `# (none, at the moment)` comment from `.chezmoitemplates/config.nu` left
  over from before the `td` alias was added there.

### `dot_zshrc` details

- **History**: mirrors nushell's intentional choices — `HISTSIZE`/`SAVEHIST` of 5 billion
  (virtually unlimited), `EXTENDED_HISTORY` for `: timestamp:elapsed;command` format,
  `INC_APPEND_HISTORY_TIME` (write after command completes to capture elapsed, mirrors
  `sync_on_enter = true`), duplicate and space filtering.
- **PATH**: `~/bin`, `~/.local/bin`, `~/.cargo/bin`, `$VOLTA_HOME/bin` — mirrors
  `dot_bash_profile.tmpl` plus the new Volta addition.
- **Completion**: `compinit` with 24-hour cache check to avoid startup latency on machines
  with many completion scripts.
- **Alias**: `td` Todoist CLI alias matching bash and nushell.

## Test plan

- [ ] Run `chezmoi diff` and confirm expected changes: new `~/.zshrc`, modified
        `~/.bash_profile`, modified `~/.config/nushell/config.nu`.
- [ ] Launch a zsh session and run `type td` to confirm the alias resolves.
- [ ] Confirm `$VOLTA_HOME` is set and `volta` is on PATH in both bash and zsh (if Volta is
        installed).
- [ ] Confirm history persists across zsh sessions via `~/.zsh_history`.

https://claude.ai/code/session_013KXScRsufTxaXHFaXwhPRu