### PR TITLE
feat: silence settings.json runtime-reorder drift via modify_ script

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -26,11 +26,11 @@ echo "✓ Shellcheck passed!"
 """
 
 [tasks.test]
-description = "Run wkflw-ntfy unit tests"
+description = "Run unit tests (wkflw-ntfy + claude)"
 run = """
-echo "Running wkflw-ntfy unit tests..."
+echo "Running unit tests..."
 # Note: Add --jobs 4 for parallel execution (Bats 1.0+ has native parallel support)
-bats test/wkflw-ntfy/unit/
+bats test/wkflw-ntfy/unit/ test/claude/
 """
 
 [tasks.ci]

--- a/private_dot_claude/modify_settings.json.tmpl
+++ b/private_dot_claude/modify_settings.json.tmpl
@@ -1,3 +1,23 @@
+#!/bin/sh
+# chezmoi modify_ script for ~/.claude/settings.json.
+#
+# settings.json is fully version-controlled here, but Claude Code rewrites it at
+# runtime and reorders its keys, which otherwise shows up as perpetual
+# `chezmoi diff` noise (and a "changed since chezmoi last wrote it" prompt).
+# chezmoi runs this with the CURRENT target file on stdin and replaces the
+# target with our stdout, so:
+#   - if the live file is semantically equal to our committed settings
+#     (ignoring key order), emit the live bytes unchanged  -> no diff;
+#   - otherwise emit the committed settings                -> any real runtime
+#     change is reverted on the next apply (chezmoi wins).
+# It self-heals: after a revert, the next runtime rewrite is semantically equal
+# again, so diffs stay quiet.
+set -eu
+
+live="$(cat)"
+[ -n "$live" ] || live='{}'
+
+desired="$(cat <<'SETTINGS_JSON'
 {
   "cleanupPeriodDays": 36525,
   "attribution": {
@@ -158,3 +178,16 @@
   "voiceEnabled": true,
   "inputNeededNotifEnabled": true
 }
+SETTINGS_JSON
+)"
+
+# Compare order-insensitively (jq -S sorts object keys recursively). If jq fails
+# on a malformed live file, fall back to emitting the committed settings.
+live_norm="$(printf '%s' "$live" | jq -S . 2>/dev/null || true)"
+desired_norm="$(printf '%s' "$desired" | jq -S .)"
+
+if [ -n "$live_norm" ] && [ "$live_norm" = "$desired_norm" ]; then
+  printf '%s' "$live"
+else
+  printf '%s' "$desired"
+fi

--- a/test/claude/modify-settings.bats
+++ b/test/claude/modify-settings.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+#
+# Tests for the `modify_settings.json` chezmoi script.
+#
+# The script must be a no-op when the live ~/.claude/settings.json differs from
+# the committed settings only by key order (so Claude Code's runtime reordering
+# doesn't cause perpetual `chezmoi diff` noise), and must revert to the committed
+# settings when any value actually differs ("chezmoi wins").
+
+setup() {
+  REPO="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SRC="$REPO/private_dot_claude/modify_settings.json.tmpl"
+
+  if ! command -v chezmoi >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
+    skip "requires chezmoi and jq"
+  fi
+
+  # Render the templated modify_ script to a runnable shell script.
+  SCRIPT="$BATS_TEST_TMPDIR/modify_settings"
+  chezmoi execute-template < "$SRC" > "$SCRIPT"
+
+  # The committed ("desired") settings are what the script emits for empty stdin.
+  DESIRED="$(printf '' | sh "$SCRIPT")"
+}
+
+@test "empty input yields valid committed settings JSON" {
+  run sh "$SCRIPT" </dev/null
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | jq -e . >/dev/null
+}
+
+@test "key reordering is emitted unchanged (no diff)" {
+  # Same data, keys sorted -> a different byte order than the committed file.
+  printf '%s' "$DESIRED" | jq -S . > "$BATS_TEST_TMPDIR/reordered.json"
+  reordered="$(cat "$BATS_TEST_TMPDIR/reordered.json")"
+  [ "$reordered" != "$DESIRED" ]   # sanity: the order really did change
+
+  run sh "$SCRIPT" < "$BATS_TEST_TMPDIR/reordered.json"
+  [ "$output" = "$reordered" ]     # live bytes passed through untouched
+}
+
+@test "a changed value is reverted to the committed settings" {
+  printf '%s' "$DESIRED" | jq '.cleanupPeriodDays = 1' > "$BATS_TEST_TMPDIR/changed.json"
+
+  run sh "$SCRIPT" < "$BATS_TEST_TMPDIR/changed.json"
+  # Output equals the committed settings, not the changed input.
+  [ "$(printf '%s' "$output" | jq -S .)" = "$(printf '%s' "$DESIRED" | jq -S .)" ]
+  [ "$(printf '%s' "$output" | jq .cleanupPeriodDays)" = "$(printf '%s' "$DESIRED" | jq .cleanupPeriodDays)" ]
+}
+
+@test "malformed input falls back to the committed settings" {
+  printf 'not json' > "$BATS_TEST_TMPDIR/bad.json"
+
+  run sh "$SCRIPT" < "$BATS_TEST_TMPDIR/bad.json"
+  [ "$(printf '%s' "$output" | jq -S .)" = "$(printf '%s' "$DESIRED" | jq -S .)" ]
+}


### PR DESCRIPTION
## Summary

Claude Code rewrites `~/.claude/settings.json` at runtime and reorders its keys, which showed up as
perpetual `chezmoi diff` noise — and an interactive "changed since chezmoi last wrote it" prompt that
breaks non-interactive `chezmoi apply`. (Surfaced during QA of #21.)

This replaces the plain `settings.json.tmpl` with a `modify_settings.json.tmpl` script that mirrors the
existing `modify_known_marketplaces.json` pattern:

- If the live file is **semantically equal** to the committed settings (compared with `jq -S`, ignoring
  key order), it emits the live bytes unchanged → **no diff**.
- Otherwise it emits the committed settings → any real runtime change is **reverted** on the next apply
  (chezmoi stays the source of truth).

It self-heals: after a revert, the next runtime rewrite is semantically equal again, so diffs stay quiet.
The committed JSON itself is unchanged (wrapped verbatim inside the script).

## Tests

`test/claude/modify-settings.bats` (wired into `mise run test`/`ci`) covers:

- key reordering → emitted unchanged (no diff)
- changed value → reverted to committed
- empty / malformed input → falls back to committed

All green via `mise run ci`.

## Manual verification

- [x] `chezmoi diff` clean after `chezmoi apply`.
- [x] Reorder a key in the live `~/.claude/settings.json` → `chezmoi diff` stays clean.
- [x] Toggle a value in the live file → `chezmoi diff` shows the revert.

